### PR TITLE
Update WoT schema URL 

### DIFF
--- a/tests/test_thing_model.py
+++ b/tests/test_thing_model.py
@@ -104,7 +104,7 @@ def test_thing_description():
     assert body["title"] == "My Lamp"
     assert body["security"] == "nosec_sc"
     assert body["securityDefinitions"]["nosec_sc"]["scheme"] == "nosec"
-    assert body["@context"] == "https://webthings.io/schemas/"
+    assert body["@context"] == "https://webthings.io/schemas"
     assert lists_equal(body["@type"], ["OnOffSwitch", "Light"])
     assert body["description"] == "A web connected lamp"
     assert body["properties"]["on"]["@type"] == "OnOffProperty"

--- a/tests/test_thing_model.py
+++ b/tests/test_thing_model.py
@@ -104,7 +104,7 @@ def test_thing_description():
     assert body["title"] == "My Lamp"
     assert body["security"] == "nosec_sc"
     assert body["securityDefinitions"]["nosec_sc"]["scheme"] == "nosec"
-    assert body["@context"] == "https://iot.mozilla.org/schemas"
+    assert body["@context"] == "https://webthings.io/schemas/"
     assert lists_equal(body["@type"], ["OnOffSwitch", "Light"])
     assert body["description"] == "A web connected lamp"
     assert body["properties"]["on"]["@type"] == "OnOffProperty"

--- a/thingtalk/models/thing.py
+++ b/thingtalk/models/thing.py
@@ -56,7 +56,7 @@ class Thing:
             self.description = description_
 
         self._id = id_
-        self._context = "https://iot.mozilla.org/schemas"
+        self._context = "https://webthings.io/schemas/"
         self._title = title
         self.properties: Dict[str, Property] = {}
         self.available_actions = {}

--- a/thingtalk/models/thing.py
+++ b/thingtalk/models/thing.py
@@ -56,7 +56,7 @@ class Thing:
             self.description = description_
 
         self._id = id_
-        self._context = "https://webthings.io/schemas/"
+        self._context = "https://webthings.io/schemas"
         self._title = title
         self.properties: Dict[str, Property] = {}
         self.available_actions = {}


### PR DESCRIPTION
See header at https://iot.mozilla.org/schemas:

Note: This document is no longer maintained and has been replaced by a new specification at webthings.io/schemas.